### PR TITLE
fix: stop generating country-prefixed URLs that fall through to WordPress

### DIFF
--- a/src/components/blocks/maxmegamenu/menu-link.tsx
+++ b/src/components/blocks/maxmegamenu/menu-link.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useEffect, useRef } from 'react';
 import { useIntersectionObserver } from 'usehooks-ts';
 import { makeLinkRelative } from '@src/lib/helpers/helper';
@@ -19,7 +19,15 @@ type StyledMenuProps = {
   $hoverBackgroundColor?: string;
 };
 
-export const StyledMenuLink = styled(Link)<StyledMenuProps>`
+/**
+ * WordPress uses `#` as the URL of a menu item that exists only to open a dropdown.
+ * It is not a destination, so it must never reach next/link: next/link resolves `#`
+ * against the current route, which turns one menu item into a different dead URL on
+ * every page of the site.
+ */
+const isNonNavigable = (href?: string) => !href || href === '#';
+
+const menuLinkStyles = css<StyledMenuProps>`
   ${(props) => {
     if (!props.$padding) return null;
 
@@ -58,6 +66,19 @@ export const StyledMenuLink = styled(Link)<StyledMenuProps>`
   }
 `;
 
+export const StyledMenuLink = styled(Link)<StyledMenuProps>`
+  ${menuLinkStyles}
+`;
+
+/**
+ * The dropdown trigger. Same element and same styling as StyledMenuLink, but with no
+ * href, so it looks and measures identically while not being a link: nothing to
+ * prefetch, nothing for a crawler to follow, and no route resolution.
+ */
+export const StyledMenuTrigger = styled.a<StyledMenuProps>`
+  ${menuLinkStyles}
+`;
+
 type Props = React.LinkHTMLAttributes<HTMLAnchorElement> & StyledMenuProps;
 
 export const MenuLink: React.FC<Props> = ({ children, href, onClick, as, ...props }) => {
@@ -67,12 +88,13 @@ export const MenuLink: React.FC<Props> = ({ children, href, onClick, as, ...prop
   const ref = useRef<HTMLDivElement | null>(null);
   const entry = useIntersectionObserver(ref, {});
   const isVisible = !!entry?.isIntersecting;
+  const nonNavigable = isNonNavigable(href);
 
   useEffect(() => {
-    if (isVisible && href) {
+    if (isVisible && href && !nonNavigable) {
       prefetch(`/${currentCountry}${makeLinkRelative(href)}`);
     }
-  }, [currentCountry, href, isVisible, prefetch]);
+  }, [currentCountry, href, isVisible, nonNavigable, prefetch]);
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (onClick) {
@@ -81,10 +103,32 @@ export const MenuLink: React.FC<Props> = ({ children, href, onClick, as, ...prop
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (!onClick || (e.key !== 'Enter' && e.key !== ' ')) return;
+    e.preventDefault();
+    onClick(e as unknown as React.MouseEvent<HTMLAnchorElement>);
+  };
+
+  if (nonNavigable) {
+    return (
+      <div ref={ref}>
+        <StyledMenuTrigger
+          role="button"
+          tabIndex={0}
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          {...props}
+        >
+          {children}
+        </StyledMenuTrigger>
+      </div>
+    );
+  }
+
   return (
     <div ref={ref}>
       <StyledMenuLink
-        href={href ? makeLinkRelative(href) : '#'}
+        href={makeLinkRelative(href as string)}
         onClick={handleClick}
         {...props}
       >

--- a/src/components/blocks/maxmegamenu/menu-link.tsx
+++ b/src/components/blocks/maxmegamenu/menu-link.tsx
@@ -2,7 +2,6 @@ import styled, { css } from 'styled-components';
 import { useEffect, useRef } from 'react';
 import { useIntersectionObserver } from 'usehooks-ts';
 import { makeLinkRelative } from '@src/lib/helpers/helper';
-import { useSiteContext } from '@src/context/site-context';
 import { useRouter } from 'next/router';
 import type { BoxControlProps } from '@components/blocks/maxmegamenu/block';
 import Link from 'next/link';
@@ -82,7 +81,6 @@ export const StyledMenuTrigger = styled.a<StyledMenuProps>`
 type Props = React.LinkHTMLAttributes<HTMLAnchorElement> & StyledMenuProps;
 
 export const MenuLink: React.FC<Props> = ({ children, href, onClick, as, ...props }) => {
-  const { currentCountry } = useSiteContext();
   const { push, prefetch } = useRouter();
 
   const ref = useRef<HTMLDivElement | null>(null);
@@ -92,9 +90,9 @@ export const MenuLink: React.FC<Props> = ({ children, href, onClick, as, ...prop
 
   useEffect(() => {
     if (isVisible && href && !nonNavigable) {
-      prefetch(`/${currentCountry}${makeLinkRelative(href)}`);
+      prefetch(makeLinkRelative(href));
     }
-  }, [currentCountry, href, isVisible, nonNavigable, prefetch]);
+  }, [href, isVisible, nonNavigable, prefetch]);
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (onClick) {

--- a/src/components/category/category-card.tsx
+++ b/src/components/category/category-card.tsx
@@ -19,7 +19,7 @@ interface Props extends ProductCards {
 export const CategoryCard = (props: Props) => {
   const { name, permalink, thumbnail } = props.taxonomies;
   const { classNames, detailsAlignment = 'center', hasBorders, imagePadding } = props;
-  const { currentCountry, settings } = useSiteContext();
+  const { settings } = useSiteContext();
 
   const [imgError, setImgError] = useState(false);
 
@@ -29,13 +29,13 @@ export const CategoryCard = (props: Props) => {
   const isVisible = !!entry?.isIntersecting;
 
   useEffect(() => {
-    if (isVisible) {
-      prefetch(`/${currentCountry}${permalink}`);
+    if (isVisible && permalink) {
+      prefetch(permalink);
     }
-  }, [isVisible, currentCountry, prefetch, permalink]);
+  }, [isVisible, prefetch, permalink]);
 
   const handleMouseEnter = () => {
-    prefetch(`/${currentCountry}${permalink}`);
+    if (permalink) prefetch(permalink);
   };
 
   const renderCardTitle = () => {

--- a/src/components/common/prefetch-link.tsx
+++ b/src/components/common/prefetch-link.tsx
@@ -4,7 +4,6 @@ import { ReactNode, useEffect, useRef } from 'react';
 import { useIntersectionObserver } from 'usehooks-ts';
 
 import { RawLink } from '@src/components/common/raw-link';
-import { useSiteContext } from '@src/context/site-context';
 import Link from 'next/link';
 
 type Props = {
@@ -30,7 +29,6 @@ export const PrefetchLink: React.FC<Props> = ({
   style = {},
   target = '_self',
 }) => {
-  const { currentCountry } = useSiteContext();
 
   const { push, prefetch } = useRouter();
   const ref = useRef<HTMLDivElement | null>(null);
@@ -39,14 +37,14 @@ export const PrefetchLink: React.FC<Props> = ({
 
   useEffect(() => {
     if (isVisible && href) {
-      prefetch(`/${currentCountry}${href}`);
+      prefetch(href);
     }
-  }, [isVisible, currentCountry, prefetch, href]);
+  }, [isVisible, prefetch, href]);
 
   if (!href) return null;
 
   const handleMouseEnter = () => {
-    prefetch(`/${currentCountry}${href}`);
+    prefetch(href);
   };
 
   return (

--- a/src/components/header/menu/menu-item.tsx
+++ b/src/components/header/menu/menu-item.tsx
@@ -64,9 +64,9 @@ export const MenuItem: React.FC<MenuItemType> = ({
 
   useEffect(() => {
     if (isVisible && href) {
-      prefetch(`/${currentCountry}${relativeLink}`);
+      prefetch(relativeLink);
     }
-  }, [isVisible, currentCountry, prefetch, href, relativeLink]);
+  }, [isVisible, prefetch, href, relativeLink]);
 
   if (component) return React.cloneElement(component, { isLast });
 
@@ -74,7 +74,7 @@ export const MenuItem: React.FC<MenuItemType> = ({
 
   const handleMouseLinkHover = () => {
     if (href) {
-      prefetch(`/${currentCountry}${relativeLink}`);
+      prefetch(relativeLink);
     }
   };
 

--- a/src/components/header/raw-menu/menu-item.tsx
+++ b/src/components/header/raw-menu/menu-item.tsx
@@ -37,7 +37,7 @@ export const MenuItem: React.FC<MenuItemType> = ({
   megaMenuItems,
   children,
 }) => {
-  const { currentCountry, settings } = useSiteContext();
+  const { settings } = useSiteContext();
 
   const { push, prefetch, asPath } = useRouter();
 
@@ -56,14 +56,14 @@ export const MenuItem: React.FC<MenuItemType> = ({
 
   useEffect(() => {
     if (isVisible && href) {
-      prefetch(`/${currentCountry}${relativeLink}`);
+      prefetch(relativeLink);
     }
-  }, [isVisible, currentCountry, prefetch, href, relativeLink]);
+  }, [isVisible, prefetch, href, relativeLink]);
 
   const handleMouseOver = () => {
     setIsHovering(true);
     if (href) {
-      prefetch(`/${currentCountry}${relativeLink}`);
+      prefetch(relativeLink);
     }
   };
 

--- a/src/components/header/search/product-hit.tsx
+++ b/src/components/header/search/product-hit.tsx
@@ -26,7 +26,7 @@ export const ProductHit = ({ hit }: any) => {
   const isFree = parseFloat(hit.price[currentCurrency]) === 0;
 
   const handleMouseEnter = () => {
-    prefetch(`/${currentCountry}${productLink}`);
+    prefetch(productLink);
   };
 
   const handleMouseClick = () => {
@@ -35,9 +35,9 @@ export const ProductHit = ({ hit }: any) => {
 
   useEffect(() => {
     if (isVisible) {
-      prefetch(`/${currentCountry}${productLink}`);
+      prefetch(productLink);
     }
-  }, [isVisible, productLink, currentCountry, prefetch]);
+  }, [isVisible, productLink, prefetch]);
 
   return (
     <div

--- a/src/components/navbar/navbar-link.tsx
+++ b/src/components/navbar/navbar-link.tsx
@@ -27,7 +27,7 @@ export const NavbarLink = ({ children, href, hasChevronDownIcon }: NavbarLinkPro
   const [isOpen, setIsOpen] = useState(false);
   const { push, prefetch } = useRouter();
   const matches = useMediaQuery('(min-width: 768px)');
-  const { settings, currentCountry } = useSiteContext();
+  const { settings } = useSiteContext();
   const { header } = settings as Settings;
 
   const ref = useRef<HTMLDivElement | null>(null);
@@ -44,13 +44,13 @@ export const NavbarLink = ({ children, href, hasChevronDownIcon }: NavbarLinkPro
 
   useEffect(() => {
     if (isVisible) {
-      prefetch(`/${currentCountry}${href}`);
+      prefetch(href);
     }
-  }, [isVisible, currentCountry, prefetch, href]);
+  }, [isVisible, prefetch, href]);
 
   const handleMouseEnter = () => {
     if (!prefetched) {
-      prefetch(`/${currentCountry}${href}`);
+      prefetch(href);
       setPrefetched(true);
     }
   };

--- a/src/features/product/cards/default.tsx
+++ b/src/features/product/cards/default.tsx
@@ -93,7 +93,7 @@ export const DefaultProductCard = (props: Props) => {
   } = props;
 
   const productLink = seoUrlParser(product?.permalink || '');
-  const { currentCurrency, settings, currentCountry } = useSiteContext();
+  const { currentCurrency, settings } = useSiteContext();
   const [showImageVariant, setShowImageVariant] = useState<string>('');
   const [hovered, setHovered] = useState(false);
   // const [compositeComponents, setCompositeComponents] = useState<CompositeProductComponent[]>();
@@ -113,12 +113,12 @@ export const DefaultProductCard = (props: Props) => {
 
   useEffect(() => {
     if (isVisible) {
-      prefetch(`/${currentCountry}${productLink}`);
+      prefetch(productLink);
     }
-  }, [isVisible, productLink, currentCountry, prefetch]);
+  }, [isVisible, productLink, prefetch]);
 
   const handleMouseEnter = () => {
-    prefetch(`/${currentCountry}${productLink}`);
+    prefetch(productLink);
   };
 
   const gliderRef = useRef<GliderMethods>(null);

--- a/src/features/product/cards/product-card.tsx
+++ b/src/features/product/cards/product-card.tsx
@@ -52,7 +52,7 @@ export const ProductCard = (props: Props) => {
 
   const productLink = seoUrlParser(product?.permalink || '');
   const thumbnailSrc = TSThumbnail.clean(product?.thumbnail?.src || '');
-  const { currentCurrency, settings, currentCountry } = useSiteContext();
+  const { currentCurrency, settings } = useSiteContext();
   // const [compositeComponents, setCompositeComponents] = useState<CompositeProductComponent[]>();
 
   const { isProductInWishList } = useWishListStorage();
@@ -73,12 +73,12 @@ export const ProductCard = (props: Props) => {
 
   useEffect(() => {
     if (isVisible) {
-      prefetch(`/${currentCountry}${productLink}`);
+      prefetch(productLink);
     }
-  }, [isVisible, productLink, currentCountry, prefetch]);
+  }, [isVisible, productLink, prefetch]);
 
   const handleMouseEnter = () => {
-    prefetch(`/${currentCountry}${productLink}`);
+    prefetch(productLink);
   };
 
   const galleryImages = product?.galleryImages;


### PR DESCRIPTION
## Summary

The same two fixes shipped to the Squadron Nostalgia fork, applied here so every site built from this
template gets them. The fork version is live in production and measured; see below.

**1. Prefetch targets.** `src/middleware.ts` maps a public path onto the internal country prefixed route,
choosing the country from the visitor cookie or edge geolocation. `/terms/` is served from the internal
path `/US/page/terms`. That prefix is never a public URL.

Seventeen hand written prefetch calls across nine components built their target as
`` `/${currentCountry}${path}` ``, prepending the country themselves. That produces a shape the middleware
never emits, so no route matches it and it falls through to the `fallback` rewrite in `next.config.js`,
which hands it to WordPress. Each one costs a full PHP boot returning a 404. The calls fire on
intersection and again on hover, so one visitor scrolling a listing page generates dozens.

Each call now passes the same path its anchor points at, so the middleware attaches the right country for
that visitor.

The two `push(href, as)` calls are left alone. They pass the internal route as `href` and the public URL
as `as`, which is correct and resolves client side with no network request.

**2. Non navigable menu items.** A menu item whose url is `#` rendered as a `next/link`, and `#` resolves
against the current route, so every page produced its own dead URL. It now renders a plain anchor with no
href and the same styling, with keyboard activation added since an anchor without href is not focusable.

### What this cost one site

Measured from the Kinsta origin logs for squadronnostalgia.com before the fix shipped:

| log day | PHP requests | country prefixed 404s | share of PHP requests | share of PHP time |
|---|---|---|---|---|
| 26 Jul | 56,661 | 24,182 | 42.7% | 37.3% |
| 27 Jul | 106,495 | 63,433 | 59.6% | 36.1% |
| 28 Jul | 92,131 | 41,860 | 45.4% | 37.4% |

## Test plan

Verified on the fork, whose components are the same, first against a preview build and then against
production after merge.

- [x] Page load and full scroll across four page types. Requests under `/US/`: 112 before, 0 after.
- [x] Hovering four nav items: 102 prefetches before, 52 of them 404. After: 47, all 200. Useful coverage
      unchanged, only the failing half gone.
- [x] Public URLs still 200 with the expected internal match: `/`, `/terms/`, `/blog/`, `/contact-us/`,
      `/shop/aircraft-models/`, `/shop/patches/`, `/shop/swag/beer-steins/`.
- [x] Seven breakpoints, 320 to 2560. Zero dead hrefs, zero country prefixed hrefs, zero `/US/` requests,
      menu opens and dropdown children render.
- [x] Typecheck at parity with main here: 115 errors before, 115 after, same list.
- [x] Every remaining `currentCountry` use is still declared. The two `push` sites keep it.

### Not covered

No preview here exercises the non navigable branch, because it depends on a menu item whose url is `#` in
the Typesense payload. To exercise it, point a build at a store that still holds `#`.

A rewrite catching `/XX/...` before the WordPress fallback saw it was tried on the fork and reverted. It
returned 404 for every public URL. `next.config.js` is untouched here.

### Why this was reopened

This PR was closed without being merged at 2026-07-29 07:32:56 UTC, seconds after the fork PR merged. That
was not intended and the work was never merged here. Reopened with the branch unchanged at `7f6e3e2`.

## Related

ClickUp task: https://app.clickup.com/t/86eyeutx6
Fork PR, merged: https://github.com/blaze-commerce/squadronnostalgia.com/pull/38

## Session Resume

```bash
cd /Users/alanregaya/Documents/.work/.blz && claude --resume 9d91f1b3-bc3b-4d20-a137-0be8a53ad290 --permission-mode plan
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
